### PR TITLE
fix/ARMA_64BIT_WORD

### DIFF
--- a/man/survival_ln_mixture.Rd
+++ b/man/survival_ln_mixture.Rd
@@ -19,7 +19,7 @@ survival_ln_mixture(
   proposal_variance = 2,
   show_progress = FALSE,
   em_iter = 150,
-  starting_seed = sample(1, 2^30, 1),
+  starting_seed = sample(1, 2^28, 1),
   ...
 )
 
@@ -55,7 +55,7 @@ The number of warmup iterations should be smaller than iter.}
 
 \item{em_iter}{A positive integer specifying the number of iterations for the EM algorithm. The EM algorithm is performed before the Gibbs sampler to find better initial values for the chains. On simulations, values lower than 200 seems to work nice.}
 
-\item{starting_seed}{Starting seed for the sampler. If not specified by the user, uses a random integer between 1 and 2^25. This way we ensure, when the user sets a seed in R, that this is passed into the C++ code.}
+\item{starting_seed}{Starting seed for the sampler. If not specified by the user, uses a random integer between 1 and 2^28 This way we ensure, when the user sets a seed in R, that this is passed into the C++ code.}
 
 \item{...}{Not currently used, but required for extensibility.}
 }

--- a/src/Makevars
+++ b/src/Makevars
@@ -11,5 +11,5 @@
 CXX_STD = CXX11
 
 # Register where the header files for the package can be found
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -I../inst/include/
+PKG_CXXFLAGS = -DARMA_64BIT_WORD=1 $(SHLIB_OPENMP_CXXFLAGS) -I../inst/include/
 PKG_LIBS = -L/usr/lib -lgsl $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -11,5 +11,5 @@
 CXX_STD = CXX11
 
 # Register where the header files for the package can be found
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -I../inst/include/
+PKG_CXXFLAGS = -DARMA_64BIT_WORD=1 $(SHLIB_OPENMP_CXXFLAGS) -I../inst/include/
 PKG_LIBS = -L/usr/lib -lgsl $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/lognormal_mixture_gibbs.cpp
+++ b/src/lognormal_mixture_gibbs.cpp
@@ -5,6 +5,8 @@
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
+#define ARMA_64BIT_WORD 1;
+
 using namespace Rcpp;
 
 // ------ RNG Framework ------

--- a/src/lognormal_mixture_gibbs.cpp
+++ b/src/lognormal_mixture_gibbs.cpp
@@ -5,8 +5,6 @@
 #include <gsl/gsl_rng.h>
 #include <gsl/gsl_randist.h>
 
-#define ARMA_64BIT_WORD 1;
-
 using namespace Rcpp;
 
 // ------ RNG Framework ------


### PR DESCRIPTION
A Milena, ao tentar ajustar o modelo para os dados da MAG, se deparou com o seguinte problema: 
"Error: SpMat::init(): requested size is too large; suggest to enable ARMA_64BIT_WORD"

e daí eu finalmente lembrei o porquê de ter colocado **#define ARMA_64BIT_WORD 1** no código em C++ anteriormente. Consegui incluir de forma que o pacote não é quebrado ao ser construído, igual estava sendo antes.